### PR TITLE
Add action tracing

### DIFF
--- a/backend/app/services/auth/user_service.py
+++ b/backend/app/services/auth/user_service.py
@@ -2,6 +2,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from app.models.user import User
+from app.services.trace_service import TraceService
 
 
 class UserService:
@@ -18,6 +19,14 @@ class UserService:
         db.add(new_user)
         await db.commit()
         await db.refresh(new_user)
+
+        await TraceService.record_trace(
+            db,
+            f"{prenom} {nom}",
+            "USER_CREATED",
+            "Creation d'un nouvel utilisateur",
+            {"user_id": new_user.id, "email": email},
+        )
 
         return new_user
 

--- a/backend/app/services/trace_service.py
+++ b/backend/app/services/trace_service.py
@@ -1,15 +1,21 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.trace import Trace
 
 class TraceService:
 
     @staticmethod
-    def record_trace(db: Session, utilisateur: str, trace_type: str, message: str, payload: dict = None):
+    async def record_trace(
+        db: AsyncSession,
+        utilisateur: str,
+        trace_type: str,
+        message: str,
+        payload: dict | None = None,
+    ):
         trace = Trace(
-            utilisateur= utilisateur,
+            utilisateur=utilisateur,
             type=trace_type,
             message=message,
             payload=payload or {},
         )
         db.add(trace)
-        db.commit()
+        await db.commit()

--- a/backend/tests/test_group_route.py
+++ b/backend/tests/test_group_route.py
@@ -48,7 +48,7 @@ async def override_get_db():
         yield session
 
 async def override_get_current_user():
-    return User(id=1, email="user@example.com", name="Test", google_id="1")
+    return User(id=1, email="user@example.com", prenom="Test", nom="User", google_id="1")
 
 app.dependency_overrides[get_db] = override_get_db
 app.dependency_overrides[get_current_user] = override_get_current_user


### PR DESCRIPTION
## Summary
- log actions in the `Trace` table via TraceService
- add trace calls for groups, gifts, users and ideas
- adjust tests for new user fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611b80906c8330a35bd447dd56e726