### PR TITLE
Add email/password auth flow

### DIFF
--- a/backend/app/routes/auth_route.py
+++ b/backend/app/routes/auth_route.py
@@ -3,10 +3,23 @@ from sqlalchemy.ext.asyncio.session import AsyncSession
 from starlette.responses import JSONResponse
 
 from app.main import get_db
-from app.schemas.auth import GoogleAuthRequest
+from app.schemas.auth import (
+    GoogleAuthRequest,
+    LoginRequest,
+    RegisterRequest,
+    CheckUserRequest,
+)
 from app.services.auth.auth_service import AuthService
 
 router = APIRouter(prefix="/api/auth", tags=["Authentification"])
+
+
+@router.post("/check-user", status_code=200)
+async def check_user(
+    request: CheckUserRequest,
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    return await AuthService.check_user(request, db)
 
 @router.post("/google", status_code=200)
 async def authenticate_with_google(
@@ -15,16 +28,33 @@ async def authenticate_with_google(
 ) -> JSONResponse:
     return await AuthService.authenticate_google_user(request, db)
 
+
+@router.post("/login", status_code=200)
+async def login(
+    request: LoginRequest,
+    db: AsyncSession = Depends(get_db)
+) -> JSONResponse:
+    return await AuthService.authenticate_email_user(request, db)
+
+
+@router.post("/register", status_code=201)
+async def register(
+    request: RegisterRequest,
+    db: AsyncSession = Depends(get_db)
+) -> JSONResponse:
+    return await AuthService.register_user(request, db)
+
 @router.post("/refresh", status_code=200)
 async def refresh_token(
         request: Request,
         db: AsyncSession = Depends(get_db)
-):
+) -> JSONResponse:
     return await AuthService.refresh_access_token(db, request)
 
 @router.post("/logout", status_code=200)
 async def logout(
         request: Request,
         db: AsyncSession = Depends(get_db)
-):
+) -> JSONResponse:
     return await AuthService.logout(db, request)
+

--- a/backend/app/schemas/auth/__init__.py
+++ b/backend/app/schemas/auth/__init__.py
@@ -1,2 +1,2 @@
-from .auth import GoogleAuthRequest
+from .auth import GoogleAuthRequest, LoginRequest, RegisterRequest, CheckUserRequest
 from .auth_jwt import AuthResponse

--- a/backend/app/schemas/auth/auth.py
+++ b/backend/app/schemas/auth/auth.py
@@ -7,3 +7,24 @@ class GoogleAuthRequest(CamelModel):
     code_verifier: str = Field(alias="codeVerifier")
     remember_me: bool
 
+
+class LoginRequest(CamelModel):
+    email: str
+    password: str
+    remember_me: bool
+
+
+class RegisterRequest(CamelModel):
+    prenom: str
+    nom: str
+    email: str | None = None
+    password: str | None = None
+    google_id: str | None = Field(default=None, alias="googleId")
+    remember_me: bool
+
+
+class CheckUserRequest(CamelModel):
+    email: str
+    is_google_login: bool = Field(alias="isGoogleLogin")
+
+

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -8,6 +8,6 @@ class UserSchema(CamelModel):
     nom: str
     prenom: str
     email: str
-    google_id: str
+    google_id: str | None = None
     date_creation: datetime
 

--- a/backend/app/utils/password_helper.py
+++ b/backend/app/utils/password_helper.py
@@ -1,0 +1,21 @@
+import os
+import base64
+import hashlib
+import hmac
+
+ITERATIONS = 100_000
+
+
+def hash_password(password: str) -> str:
+    salt = os.urandom(16)
+    dk = hashlib.pbkdf2_hmac('sha256', password.encode(), salt, ITERATIONS)
+    return base64.b64encode(salt + dk).decode()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    data = base64.b64decode(hashed.encode())
+    salt = data[:16]
+    dk = data[16:]
+    new_dk = hashlib.pbkdf2_hmac('sha256', password.encode(), salt, ITERATIONS)
+    return hmac.compare_digest(dk, new_dk)
+

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,10 +1,15 @@
 import {Routes} from '@angular/router';
 import {WelcomeComponent} from 'src/pages/welcome/welcome.component';
+import {RegisterComponent} from 'src/pages/register/register.component';
 
 export const routes: Routes = [
   {
     path: '',
     component: WelcomeComponent,
+  },
+  {
+    path: 'register',
+    component: RegisterComponent,
   },
   {
     path: 'groupe',

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -6,7 +6,7 @@ export const environment = {
   issuer: 'https://accounts.google.com',
 
   api: {
-    auth: '/auth/google',
+    auth: '/auth',
     groupes: '/groupe',
     rejoindre: '/rejoindre',
     cadeaux: '/cadeaux',

--- a/frontend/src/pages/register/register.component.html
+++ b/frontend/src/pages/register/register.component.html
@@ -1,0 +1,32 @@
+<div class="form-container">
+  <h1>> Création de compte</h1>
+  <form (ngSubmit)="submit()">
+    <label for="prenom">Prénom</label>
+    <input id="prenom" type="text" [(ngModel)]="prenom" name="prenom" required>
+
+    <label for="nom">Nom</label>
+    <input id="nom" type="text" [(ngModel)]="nom" name="nom" required>
+
+    <label *ngIf="email !== null" for="email">Email</label>
+    <input *ngIf="email !== null" id="email" type="email" [(ngModel)]="email" name="email" [readonly]="true">
+
+    <label *ngIf="password !== null" for="password">Mot de passe</label>
+    <input *ngIf="password !== null" id="password" type="password" [(ngModel)]="password" name="password" required>
+
+    <div class="checkbox-row">
+      <label>
+        <input type="checkbox" [(ngModel)]="stayLoggedIn" name="stayLoggedIn"> Rester connecté
+      </label>
+    </div>
+
+    <button type="submit" class="google-btn">Créer mon compte</button>
+  </form>
+
+  <app-terminal-modal
+    *ngIf="errorService.errorMessage()"
+    [message]="errorService.errorMessage()!"
+    [actions]="[{ label: 'Ok', eventName: 'CLOSE', style: 'danger' }]"
+    (actionClicked)="errorService.clearError()"
+  ></app-terminal-modal>
+</div>
+<app-feedback-test [composant]="composant"></app-feedback-test>

--- a/frontend/src/pages/register/register.component.scss
+++ b/frontend/src/pages/register/register.component.scss
@@ -1,0 +1,7 @@
+.google-btn {
+  display: block;
+  margin-top: 1rem;
+}
+.checkbox-row {
+  margin-top: 1rem;
+}

--- a/frontend/src/pages/register/register.component.ts
+++ b/frontend/src/pages/register/register.component.ts
@@ -1,0 +1,49 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { AuthService } from 'src/security/service/auth.service';
+import { ErrorService } from 'src/core/services/error.service';
+import { RegisterRequest } from 'src/security/model/register-request.model';
+import { TerminalModalComponent } from 'src/shared/components/terminal-modal/terminal-modal.component';
+import { FeedbackTestComponent } from 'src/shared/components/feedback-test/feedback-test.component';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TerminalModalComponent, FeedbackTestComponent],
+  templateUrl: './register.component.html',
+  styleUrl: './register.component.scss'
+})
+export class RegisterComponent {
+  prenom = '';
+  nom = '';
+  email: string | null = null;
+  password: string | null = null;
+  stayLoggedIn = false;
+  composant: string = 'RegisterComponent';
+
+  constructor(private route: ActivatedRoute,
+              private auth: AuthService,
+              public errorService: ErrorService) {
+    this.route.queryParams.subscribe(params => {
+      this.email = params['email'] ?? null;
+      this.password = params['password'] ?? null;
+      this.stayLoggedIn = params['rememberMe'] === 'true';
+    });
+  }
+
+  async submit(): Promise<void> {
+    const payload: RegisterRequest = {
+      prenom: this.prenom,
+      nom: this.nom,
+      email: this.email || undefined,
+      password: this.password || undefined,
+      rememberMe: this.stayLoggedIn
+    };
+    const result = await this.auth.register(payload);
+    if (!result.success) {
+      this.errorService.showError(result.message);
+    }
+  }
+}

--- a/frontend/src/pages/welcome/welcome.component.html
+++ b/frontend/src/pages/welcome/welcome.component.html
@@ -63,6 +63,13 @@
       </div>
 
       <button class="google-btn" (click)="submitEmailPassword()">Connexion / Création de compte</button>
+
+      <app-terminal-modal
+        *ngIf="errorService.errorMessage()"
+        [message]="errorService.errorMessage()!"
+        [actions]="[{ label: 'Ok', eventName: 'CLOSE', style: 'danger' }]"
+        (actionClicked)="errorService.clearError()"
+      ></app-terminal-modal>
     </div>
   </div>
 

--- a/frontend/src/pages/welcome/welcome.component.ts
+++ b/frontend/src/pages/welcome/welcome.component.ts
@@ -5,13 +5,15 @@ import {LoadingComponent} from 'src/shared/components/loading/loading.component'
 import {GroupService} from 'src/core/services/group.service';
 import {FormsModule} from '@angular/forms';
 import {LoginRequest} from 'src/security/model/login-request.model';
+import {ErrorService} from 'src/core/services/error.service';
+import {TerminalModalComponent} from 'src/shared/components/terminal-modal/terminal-modal.component';
 
 @Component({
   selector: 'app-welcome',
   standalone: true,
   templateUrl: './welcome.component.html',
   styleUrls: ['./welcome.component.scss'],
-  imports: [CommonModule, LoadingComponent, FormsModule],
+  imports: [CommonModule, LoadingComponent, FormsModule, TerminalModalComponent],
 })
 export class WelcomeComponent {
 
@@ -25,10 +27,12 @@ export class WelcomeComponent {
   passwordError = '';
 
 
-  constructor(public auth: AuthService, public groupeService: GroupService) {
+  constructor(public auth: AuthService,
+              public groupeService: GroupService,
+              public errorService: ErrorService) {
   }
 
-  submitEmailPassword(): void {
+  async submitEmailPassword(): Promise<void> {
     this.auth.rememberMe.set(this.stayLoggedIn);
     const credentials: LoginRequest = {
       email: this.email ?? '',
@@ -36,7 +40,10 @@ export class WelcomeComponent {
       rememberMe: this.stayLoggedIn
     };
 
-    this.auth.loginWithCredentials(credentials);
+    const result = await this.auth.loginWithCredentials(credentials);
+    if (!result.success) {
+      this.errorService.showError(result.message);
+    }
   }
 
 

--- a/frontend/src/security/model/check-user-request.model.ts
+++ b/frontend/src/security/model/check-user-request.model.ts
@@ -1,0 +1,4 @@
+export interface CheckUserRequest {
+  email: string;
+  isGoogleLogin: boolean;
+}

--- a/frontend/src/security/model/register-request.model.ts
+++ b/frontend/src/security/model/register-request.model.ts
@@ -1,0 +1,8 @@
+export interface RegisterRequest {
+  prenom: string;
+  nom: string;
+  email?: string;
+  password?: string;
+  googleId?: string;
+  rememberMe: boolean;
+}


### PR DESCRIPTION
## Summary
- add routes for login, register and user check
- implement password hashing with pbkdf2
- support email/password auth in service layer
- adjust schemas for new auth flow
- update tests and add new auth tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68724d4d6d5c8330a0bda9b6d2eab178