### PR TITLE
Fix password reset form context

### DIFF
--- a/backend/app/routes/auth_route.py
+++ b/backend/app/routes/auth_route.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Body
 from sqlalchemy.ext.asyncio.session import AsyncSession
 from starlette.responses import JSONResponse
 
@@ -51,14 +51,16 @@ async def logout(
 
 @router.post("/request-password-reset", status_code=204)
 async def check_password(
-        mail: str,
+        mail: str = Body(embed=True),
         db: AsyncSession = Depends(get_db)
 ):
     await AuthService.request_password_reset(db, mail)
 
 @router.post("/verify-reset-token", status_code=200)
-async def verify_reset_token(token: str,
-                             db: AsyncSession = Depends(get_db)) -> str:
+async def verify_reset_token(
+        token: str = Body(embed=True),
+        db: AsyncSession = Depends(get_db)
+) -> str:
     return await AuthService.verify_reset_token(db, token)
 
 @router.patch("/complete-profile", status_code=200)

--- a/backend/tests/test_group_route.py
+++ b/backend/tests/test_group_route.py
@@ -11,6 +11,8 @@ os.environ['JWK_URI'] = 'http://localhost/jwk'
 os.environ['JWT_SECRET'] = 'secret'
 os.environ['DATABASE_URL'] = 'sqlite+aiosqlite:///:memory:'
 os.environ['SYNC_DB_URL'] = 'sqlite:///:memory:'
+os.environ['CHECK_MAIL'] = 'http://localhost/check_mail'
+os.environ['RESET_PASSWORD'] = 'http://localhost/reset-password?token='
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -21,7 +23,7 @@ from sqlalchemy.pool import StaticPool
 
 from app.main import app
 from app.database import Base, get_db
-from app.dependencies.current_user import get_current_user
+from app.dependencies.current_user import get_current_user_from_cookie
 from app.models import User
 
 # Create an isolated in-memory database for the tests
@@ -51,7 +53,7 @@ async def override_get_current_user():
     return User(id=1, email="user@example.com", prenom="Test", nom="User", google_id="1")
 
 app.dependency_overrides[get_db] = override_get_db
-app.dependency_overrides[get_current_user] = override_get_current_user
+app.dependency_overrides[get_current_user_from_cookie] = override_get_current_user
 
 client = TestClient(app)
 

--- a/frontend/src/pages/auth/reset-password/reset-password.component.ts
+++ b/frontend/src/pages/auth/reset-password/reset-password.component.ts
@@ -45,23 +45,24 @@ export class ResetPasswordComponent implements OnInit{
 
   async ngOnInit(): Promise<void> {
     this.user = this.authService.incompleteUser();
+    const contextParam = this.route.snapshot.queryParamMap.get('context') as 'change' | 'reset' | null;
     const token = this.route.snapshot.queryParamMap.get('token');
 
-    if(!token){
-      this.errorService.showError("Une erreur s'est produite lors de votre réinitialisation de mot de passe. Veuillez réessayer.")
-    } else {
+    if (token) {
       this.tokenResetPassword = token;
       try {
-         await this.authService.verifyResetToken(token);
-         this.context = 'reset';
+        await this.authService.verifyResetToken(token);
+        this.context = 'reset';
       } catch (err) {
-        this.errorService.showError("Une erreur s'est produite lors de votre réinitialisation de mot de passe. Veuillez réessayer.")
+        this.errorService.showError("Une erreur s'est produite lors de votre réinitialisation de mot de passe. Veuillez réessayer.");
       }
+    } else if (!contextParam) {
+      this.errorService.showError("Une erreur s'est produite lors de votre réinitialisation de mot de passe. Veuillez réessayer.");
     }
 
-    const contexteBrut = this.route.snapshot.queryParamMap.get('context');
-    const contextValide = ['change', 'reset'].includes(contexteBrut ?? '');
-    this.context = (contextValide ? contexteBrut : 'change') as 'change' | 'reset';
+    if (contextParam) {
+      this.context = contextParam;
+    }
 
     console.log(this.context);
   }


### PR DESCRIPTION
## Summary
- accept token/email in request body for password reset endpoints
- fix context detection in reset password component
- adjust tests to work with new imports and env vars

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ba77acf008330a07a6b66e874c861