### PR TITLE
Add custom toastr and banner

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -36,7 +36,6 @@
               "src/styles/retro-terminal.scss",
               "src/styles/form-styles.scss",
               "src/styles/styles.scss",
-              "node_modules/ngx-toastr/toastr.css",
               "node_modules/quill/dist/quill.snow.css"
             ],
             "scripts": []

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,6 @@
         "date-fns": "^4.1.0",
         "jwt-decode": "^4.0.0",
         "ngx-quill": "^27.1.2",
-        "ngx-toastr": "^19.0.0",
         "quill": "^2.0.3",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -10672,20 +10671,6 @@
         "@angular/core": "^19.0.0",
         "quill": "^2.0.0",
         "rxjs": "^7.0.0"
-      }
-    },
-    "node_modules/ngx-toastr": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-19.0.0.tgz",
-      "integrity": "sha512-6pTnktwwWD+kx342wuMOWB4+bkyX9221pAgGz3SHOJH0/MI9erLucS8PeeJDFwbUYyh75nQ6AzVtolgHxi52dQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": ">=16.0.0-0",
-        "@angular/core": ">=16.0.0-0",
-        "@angular/platform-browser": ">=16.0.0-0"
       }
     },
     "node_modules/node-addon-api": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "date-fns": "^4.1.0",
     "jwt-decode": "^4.0.0",
     "ngx-quill": "^27.1.2",
-    "ngx-toastr": "^19.0.0",
     "quill": "^2.0.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,9 +1,13 @@
+<app-global-header-context (heightChange)="updateHeaderHeight($event)"></app-global-header-context>
+<app-global-toastr (heightChange)="updateToastrHeight($event)"></app-global-toastr>
+
 <div *ngIf="auth.profile()?.isCompteTiers" class="sr-only" aria-live="polite" role="status">
   Vous êtes connecté en tant que compte tiers. Certaines fonctionnalités sont désactivées.
 </div>
 
-
-<router-outlet/>
+<div class="app-content" [style.marginTop.px]="offset()">
+  <router-outlet></router-outlet>
+</div>
 
 <app-terminal-modal
   *ngIf="errorService.errorMessage()"

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -1,0 +1,3 @@
+.app-content {
+  padding: 1rem;
+}

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import {Component, effect, inject, Injector, runInInjectionContext} from '@angular/core';
+import {Component, effect, inject, Injector, runInInjectionContext, signal} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {AuthService} from 'src/security/service/auth.service';
 import {GroupService} from 'src/core/services/group.service';
@@ -7,14 +7,27 @@ import {ErrorService} from 'src/core/services/error.service';
 import {TerminalModalComponent} from 'src/shared/components/terminal-modal/terminal-modal.component';
 import {GroupContextService} from 'src/core/services/group-context.service';
 import {ThemeService} from 'src/core/services/theme.service';
+import {GlobalHeaderContextComponent} from 'src/shared/components/global-header-context/global-header-context.component';
+import {GlobalToastrComponent} from 'src/shared/components/global-toastr/global-toastr.component';
+import {ContextBannerService} from 'src/core/services/context-banner.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [CommonModule, RouterOutlet, TerminalModalComponent],
+  imports: [
+    CommonModule,
+    RouterOutlet,
+    TerminalModalComponent,
+    GlobalHeaderContextComponent,
+    GlobalToastrComponent,
+  ],
   templateUrl: './app.component.html',
 })
 export class AppComponent {
+
+  offset = signal(0);
+  private headerHeight = signal(0);
+  private toastHeight = signal(0);
 
   constructor(
     public auth: AuthService,
@@ -47,9 +60,16 @@ export class AppComponent {
   }
 
   private watchCompteTiersStatus() {
+    const banner = inject(ContextBannerService);
     effect(() => {
       const user = this.auth.profile();
-      document.body.classList.toggle('compte-tiers', !!user?.isCompteTiers);
+      const isTiers = !!user?.isCompteTiers;
+      document.body.classList.toggle('compte-tiers', isTiers);
+      if (isTiers) {
+        banner.show('Connecté en tant que compte tiers');
+      } else {
+        banner.clear();
+      }
     });
   }
 
@@ -83,6 +103,20 @@ export class AppComponent {
     }
 
     this.groupService.isLoading.set(false);
+  }
+
+  updateHeaderHeight(h: number) {
+    this.headerHeight.set(h);
+    this.computeOffset();
+  }
+
+  updateToastrHeight(h: number) {
+    this.toastHeight.set(h);
+    this.computeOffset();
+  }
+
+  private computeOffset() {
+    this.offset.set(this.headerHeight() + this.toastHeight());
   }
 
 }

--- a/frontend/src/core/services/context-banner.service.ts
+++ b/frontend/src/core/services/context-banner.service.ts
@@ -1,0 +1,14 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ContextBannerService {
+  message = signal<string | null>(null);
+
+  show(message: string) {
+    this.message.set(message);
+  }
+
+  clear() {
+    this.message.set(null);
+  }
+}

--- a/frontend/src/core/services/toastr.service.ts
+++ b/frontend/src/core/services/toastr.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, signal } from '@angular/core';
+
+export type ToastType = 'success' | 'error' | 'info' | 'warning';
+export interface ToastOptions {
+  message: string;
+  type?: ToastType;
+  duration?: number;
+}
+
+interface Toast extends ToastOptions {
+  id: number;
+  type: ToastType;
+  duration: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastrService {
+  private toasts = signal<Toast[]>([]);
+
+  show(options: ToastOptions) {
+    const toast: Toast = {
+      id: Date.now() + Math.random(),
+      message: options.message,
+      type: options.type ?? 'info',
+      duration: options.duration ?? 3000,
+    };
+    this.toasts.update(ts => [...ts, toast]);
+    setTimeout(() => this.remove(toast.id), toast.duration);
+  }
+
+  remove(id: number) {
+    this.toasts.update(ts => ts.filter(t => t.id !== id));
+  }
+
+  toastsSignal() {
+    return this.toasts.asReadonly();
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,7 +8,6 @@ import {routes} from 'src/app/app.routes';
 import {registerLocaleData} from '@angular/common';
 import localeFr from '@angular/common/locales/fr';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {provideToastr} from 'ngx-toastr';
 import {StartupService} from 'src/core/services/startup.service';
 import {AuthInterceptor} from 'src/core/interceptors/auth.interceptor';
 
@@ -23,7 +22,6 @@ bootstrapApplication(AppComponent, {
     ),
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
     importProvidersFrom(OAuthModule.forRoot(), BrowserAnimationsModule),
-    provideToastr({ positionClass: 'toast-bottom-right' }),
     provideAppInitializer(async () => {
       const startup = inject(StartupService);
       await startup.handleAppStartup();

--- a/frontend/src/pages/auth/reset-password/reset-password.component.ts
+++ b/frontend/src/pages/auth/reset-password/reset-password.component.ts
@@ -7,7 +7,7 @@ import {AuthService} from 'src/security/service/auth.service';
 import {ErrorService} from 'src/core/services/error.service';
 import {ActivatedRoute, Router} from '@angular/router';
 import {ChangePassword} from 'src/security/model/change-password.model';
-import {ToastrService} from 'ngx-toastr';
+import {ToastrService} from 'src/core/services/toastr.service';
 
 @Component({
   selector: 'app-reset-password',
@@ -41,7 +41,7 @@ export class ResetPasswordComponent implements OnInit{
   constructor(
     private authService: AuthService,
     public errorService: ErrorService,
-    private toastr: ToastrService,
+    private toastrService: ToastrService,
     public router: Router
   ) {}
 
@@ -124,7 +124,7 @@ export class ResetPasswordComponent implements OnInit{
       }
       try {
         await this.authService.submitPasswordChange(changePassword);
-        this.toastr.success('Changement de mot de passe confirmé 👍');
+        this.toastrService.show({ message: 'Changement de mot de passe confirmé 👍', type: 'success' });
         void this.router.navigate(['profile']);
         return;
       } catch (err) {

--- a/frontend/src/pages/compte-tiers/managed-accounts/managed-accounts.component.ts
+++ b/frontend/src/pages/compte-tiers/managed-accounts/managed-accounts.component.ts
@@ -12,7 +12,7 @@ import {TerminalModalAction} from 'src/core/models/terminal-modal-action.model';
 import {ModalActionType} from 'src/core/enum/modal-action.enum';
 import {GroupService} from 'src/core/services/group.service';
 import {ExportManagedAccountRequest} from 'src/core/models/export-managed-account-request.model';
-import {ToastrService} from 'ngx-toastr';
+import {ToastrService} from 'src/core/services/toastr.service';
 import {GroupResume} from 'src/core/models/group/group-resume.model';
 import {GroupContextService} from 'src/core/services/group-context.service';
 
@@ -48,7 +48,7 @@ export class ManagedAccountsComponent implements OnInit{
               private userGroupService: UserGroupService,
               public errorService: ErrorService,
               private authService: AuthService,
-              private toastr: ToastrService,
+              private toastrService: ToastrService,
               public router: Router) {
   }
 
@@ -174,7 +174,7 @@ export class ManagedAccountsComponent implements OnInit{
     }
     const result = await this.userGroupService.exportTiersToGroup(request);
     if(result.success){
-      this.toastr.success("L'opération s'est terminée avec succès !");
+      this.toastrService.show({ message: "L'opération s'est terminée avec succès !", type: 'success' });
       this.showExportUser = false;
     } else {
       this.showExportUser = false;

--- a/frontend/src/pages/dashboard-group/group-invite/group-invite.component.ts
+++ b/frontend/src/pages/dashboard-group/group-invite/group-invite.component.ts
@@ -6,7 +6,7 @@ import {ErrorService} from 'src/core/services/error.service';
 import {InviteRequest} from 'src/core/models/mailing/invite-request.model';
 import {TerminalModalComponent} from 'src/shared/components/terminal-modal/terminal-modal.component';
 import {GroupService} from 'src/core/services/group.service';
-import {ToastrService} from 'ngx-toastr';
+import {ToastrService} from 'src/core/services/toastr.service';
 
 @Component({
   selector: 'app-group-invite',
@@ -30,7 +30,7 @@ export class GroupInviteComponent {
   constructor(private mailingService: MailingService,
               public errorService: ErrorService,
               private groupeService: GroupService,
-              private toastr: ToastrService) {
+              private toastrService: ToastrService) {
   }
 
   private isValidEmail(email: string): boolean {
@@ -86,7 +86,7 @@ export class GroupInviteComponent {
     }
     const result = await this.groupeService.regenererCodeInvitation(this.groupId);
     if(result.success){
-      this.toastr.success('Le code d\'invitation du groupe a bien été modifié 👍');
+      this.toastrService.show({ message: "Le code d'invitation du groupe a bien été modifié 👍", type: 'success' });
     } else {
       this.errorService.showError('Veuillez réessayer plus tard.');
     }

--- a/frontend/src/pages/dashboard/gift-ideas/my-gifts-ideas/my-gifts-ideas.component.ts
+++ b/frontend/src/pages/dashboard/gift-ideas/my-gifts-ideas/my-gifts-ideas.component.ts
@@ -11,7 +11,7 @@ import {GiftStatutDTO} from 'src/core/models/gift/gift-statut.model';
 import {TerminalModalAction} from 'src/core/models/terminal-modal-action.model';
 import {ModalActionType} from 'src/core/enum/modal-action.enum';
 import {FormsModule} from '@angular/forms';
-import {ToastrService} from 'ngx-toastr';
+import {ToastrService} from 'src/core/services/toastr.service';
 import {DisplayNamePipe} from 'src/core/pipes/display-name.pipe';
 import {UserDisplay} from 'src/core/models/user-display.model';
 import {GroupContextService} from 'src/core/services/group-context.service';
@@ -52,7 +52,7 @@ export class MyGiftsIdeasComponent implements OnInit {
               private groupContextService : GroupContextService,
               private router: Router,
               public errorService: ErrorService,
-              private toastr: ToastrService,
+              private toastrService: ToastrService,
               private userService: UserService) {
     this.membersSignal = this.groupContextService.getMembersSignal();
   }
@@ -145,7 +145,7 @@ export class MyGiftsIdeasComponent implements OnInit {
 
     if(result.success){
       await this.loadIdeas()
-      this.toastr.success('Duplication confirmée 👍');
+      this.toastrService.show({ message: 'Duplication confirmée 👍', type: 'success' });
       this.showDuplicationModal = false;
       await this.router.navigate(['/dashboard/idees'])
     } else {

--- a/frontend/src/shared/components/global-header-context/global-header-context.component.html
+++ b/frontend/src/shared/components/global-header-context/global-header-context.component.html
@@ -1,0 +1,8 @@
+<div
+  *ngIf="message()"
+  #banner
+  class="context-banner"
+  role="status"
+>
+  {{ message() }}
+</div>

--- a/frontend/src/shared/components/global-header-context/global-header-context.component.scss
+++ b/frontend/src/shared/components/global-header-context/global-header-context.component.scss
@@ -1,0 +1,15 @@
+:host {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1000;
+}
+
+.context-banner {
+  background-color: var(--color-highlight-muted);
+  color: var(--color-bg);
+  text-align: center;
+  padding: 0.5rem 1rem;
+  font-weight: bold;
+}

--- a/frontend/src/shared/components/global-header-context/global-header-context.component.ts
+++ b/frontend/src/shared/components/global-header-context/global-header-context.component.ts
@@ -1,0 +1,30 @@
+import { AfterViewInit, Component, ElementRef, EventEmitter, Output, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ContextBannerService } from 'src/core/services/context-banner.service';
+import { effect } from '@angular/core';
+
+@Component({
+  selector: 'app-global-header-context',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './global-header-context.component.html',
+  styleUrl: './global-header-context.component.scss'
+})
+export class GlobalHeaderContextComponent implements AfterViewInit {
+  message = this.bannerService.message;
+
+  @ViewChild('banner') bannerRef?: ElementRef<HTMLDivElement>;
+  @Output() heightChange = new EventEmitter<number>();
+
+  constructor(private bannerService: ContextBannerService) {}
+
+  ngAfterViewInit() {
+    effect(() => {
+      const msg = this.message();
+      setTimeout(() => {
+        const h = msg && this.bannerRef ? this.bannerRef.nativeElement.offsetHeight : 0;
+        this.heightChange.emit(h);
+      });
+    });
+  }
+}

--- a/frontend/src/shared/components/global-toastr/global-toastr.component.html
+++ b/frontend/src/shared/components/global-toastr/global-toastr.component.html
@@ -1,0 +1,9 @@
+<div class="toastr-container" #container>
+  <div
+    *ngFor="let toast of toasts()"
+    class="toast toast-{{ toast.type }}"
+    [attr.role]="toast.type === 'error' ? 'alert' : 'status'"
+  >
+    {{ toast.message }}
+  </div>
+</div>

--- a/frontend/src/shared/components/global-toastr/global-toastr.component.scss
+++ b/frontend/src/shared/components/global-toastr/global-toastr.component.scss
@@ -1,0 +1,42 @@
+.toastr-container {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1100;
+  top: 0; /* actual position will be adjusted via margin from header in AppComponent */
+}
+
+.toast {
+  background-color: var(--color-toast-bg);
+  color: var(--color-text);
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  max-width: 320px;
+  font-family: var(--font-family-base);
+}
+
+.toast-success {
+  background-color: var(--color-toast-success);
+  color: black;
+  font-weight: bold;
+}
+
+.toast-error {
+  background-color: var(--color-error);
+  color: white;
+  font-weight: bold;
+}
+
+.toast-info {
+  background-color: var(--color-highlight);
+  color: black;
+}
+
+.toast-warning {
+  background-color: var(--color-highlight-muted);
+  color: black;
+}

--- a/frontend/src/shared/components/global-toastr/global-toastr.component.ts
+++ b/frontend/src/shared/components/global-toastr/global-toastr.component.ts
@@ -1,0 +1,29 @@
+import { AfterViewInit, Component, ElementRef, EventEmitter, Output, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastrService } from 'src/core/services/toastr.service';
+import { effect } from '@angular/core';
+
+@Component({
+  selector: 'app-global-toastr',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './global-toastr.component.html',
+  styleUrl: './global-toastr.component.scss'
+})
+export class GlobalToastrComponent implements AfterViewInit {
+  toasts = this.toastrService.toastsSignal();
+
+  @ViewChild('container') containerRef?: ElementRef<HTMLDivElement>;
+  @Output() heightChange = new EventEmitter<number>();
+
+  constructor(private toastrService: ToastrService) {}
+
+  ngAfterViewInit() {
+    effect(() => {
+      setTimeout(() => {
+        const height = this.containerRef?.nativeElement.offsetHeight ?? 0;
+        this.heightChange.emit(height);
+      });
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add `ContextBannerService` for global header messages
- add `ToastrService` for custom toast notifications
- render `app-global-header-context` and `app-global-toastr` in `AppComponent`
- shift content dynamically based on banner and toast heights
- replace all old `ngx-toastr` calls
- drop `ngx-toastr` dependency and its stylesheet

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c06543788330ad8c8e858dea7e3e