### PR TITLE
Add responsive footer

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -9,6 +9,8 @@
   <router-outlet></router-outlet>
 </div>
 
+<app-global-footer></app-global-footer>
+
 <app-terminal-modal
   *ngIf="errorService.errorMessage()"
   [message]="errorService.errorMessage()!"

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -1,3 +1,10 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .app-content {
+  flex: 1 0 auto;
   padding: 1rem;
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -9,6 +9,7 @@ import {GroupContextService} from 'src/core/services/group-context.service';
 import {ThemeService} from 'src/core/services/theme.service';
 import {GlobalHeaderContextComponent} from 'src/shared/components/global-header-context/global-header-context.component';
 import {GlobalToastrComponent} from 'src/shared/components/global-toastr/global-toastr.component';
+import {GlobalFooterComponent} from 'src/shared/components/global-footer/global-footer.component';
 import {ContextBannerService} from 'src/core/services/context-banner.service';
 
 @Component({
@@ -20,6 +21,7 @@ import {ContextBannerService} from 'src/core/services/context-banner.service';
     TerminalModalComponent,
     GlobalHeaderContextComponent,
     GlobalToastrComponent,
+    GlobalFooterComponent,
   ],
   templateUrl: './app.component.html',
 })

--- a/frontend/src/assets/docs/mentions-legales.pdf
+++ b/frontend/src/assets/docs/mentions-legales.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 18 Tf
+72 100 Td
+(This is a placeholder) Tj
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000121 00000 n 
+0000000201 00000 n 
+trailer
+<< /Root 1 0 R /Size 5 >>
+startxref
+270
+%%EOF

--- a/frontend/src/shared/components/global-footer/global-footer.component.html
+++ b/frontend/src/shared/components/global-footer/global-footer.component.html
@@ -1,0 +1,5 @@
+<footer class="footer-links">
+  <a href="/assets/docs/mentions-legales.pdf" target="_blank" rel="noopener">Mentions légales</a>
+  <span class="separator" aria-hidden="true">|</span>
+  <a href="mailto:app.moments.ep@gmail.com">Contactez-nous</a>
+</footer>

--- a/frontend/src/shared/components/global-footer/global-footer.component.scss
+++ b/frontend/src/shared/components/global-footer/global-footer.component.scss
@@ -1,0 +1,29 @@
+:host {
+  display: block;
+  text-align: center;
+  padding: 1rem 0;
+  font-size: 0.9rem;
+  color: var(--color-muted-text);
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+a {
+  color: var(--color-muted-text-strong);
+  text-decoration: underline;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-highlight);
+}
+
+.separator {
+  margin: 0 0.25rem;
+}

--- a/frontend/src/shared/components/global-footer/global-footer.component.ts
+++ b/frontend/src/shared/components/global-footer/global-footer.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-global-footer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './global-footer.component.html',
+  styleUrl: './global-footer.component.scss'
+})
+export class GlobalFooterComponent {}


### PR DESCRIPTION
## Summary
- create `GlobalFooter` component with legal notice and contact links
- register footer in `AppComponent`
- update app layout to push footer to bottom
- include placeholder legal notice PDF

## Testing
- `pytest backend/tests/test_group_route.py`
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887ce4b97bc8330b7f0b1f5a7ba33f7