### PR TITLE
feat: group followed gifts by account

### DIFF
--- a/frontend/src/pages/dashboard/suivi-cadeaux-reserves/my-gifts-follow-up/my-gifts-follow-up.component.html
+++ b/frontend/src/pages/dashboard/suivi-cadeaux-reserves/my-gifts-follow-up/my-gifts-follow-up.component.html
@@ -28,23 +28,26 @@
     </thead>
     <tbody *ngIf="displayedColumns.length > 0 && tableRows.length > 0">
       <ng-container *ngFor="let row of tableRows">
-        <tr *ngIf="row.title !== undefined" class="separator-row">
-          <td [attr.colspan]="displayedColumns.length">
-            {{ row.title }} — {{ Number(row.total.toFixed(2)) }} €
-          </td>
-        </tr>
-        <tr *ngIf="row.title === undefined"
-            (click)="onGiftClicked(row as GiftFollowed)"
-            [class.recu]="(row as GiftFollowed).delivery?.recu"
-            [class.partage]="(row as GiftFollowed).gift.statut === 'PARTAGE'"
-            [attr.aria-label]="getAriaLabel(row as GiftFollowed)">
-          <td *ngFor="let column of displayedColumns"
-              tabindex="0"
-              (keydown.enter)="onGiftClicked(row as GiftFollowed)"
-              (keydown.space)="onGiftClicked(row as GiftFollowed)">
-            {{ getGiftValue(row as GiftFollowed, column) }}
-          </td>
-        </tr>
+        <ng-container *ngIf="isGroupRow(row); else giftRow">
+          <tr class="separator-row">
+            <td [attr.colspan]="displayedColumns.length">
+              {{ row.title }} — {{ Number(row.total.toFixed(2)) }} €
+            </td>
+          </tr>
+        </ng-container>
+        <ng-template #giftRow>
+          <tr (click)="onGiftClicked(row)"
+              [class.recu]="row.delivery?.recu"
+              [class.partage]="row.gift.statut === 'PARTAGE'"
+              [attr.aria-label]="getAriaLabel(row)">
+            <td *ngFor="let column of displayedColumns"
+                tabindex="0"
+                (keydown.enter)="onGiftClicked(row)"
+                (keydown.space)="onGiftClicked(row)">
+              {{ getGiftValue(row, column) }}
+            </td>
+          </tr>
+        </ng-template>
       </ng-container>
     </tbody>
   </table>

--- a/frontend/src/pages/dashboard/suivi-cadeaux-reserves/my-gifts-follow-up/my-gifts-follow-up.component.html
+++ b/frontend/src/pages/dashboard/suivi-cadeaux-reserves/my-gifts-follow-up/my-gifts-follow-up.component.html
@@ -26,18 +26,26 @@
       <th scope="col" *ngFor="let column of displayedColumns">{{ column.label || column.key | titlecase }}</th>
     </tr>
     </thead>
-    <tbody *ngIf="displayedColumns.length > 0 && giftsFollowed.length > 0">
-    <tr *ngFor="let gift of giftsFollowed" (click)="onGiftClicked(gift)"
-        [class.recu]="gift.delivery?.recu"
-        [class.partage]="gift.gift.statut === 'PARTAGE'"
-        [attr.aria-label]="getAriaLabel(gift)">
-      <td *ngFor="let column of displayedColumns"
-          tabindex="0"
-          (keydown.enter)="onGiftClicked(gift)"
-          (keydown.space)="onGiftClicked(gift)">
-        {{ getGiftValue(gift, column) }}
-      </td>
-    </tr>
+    <tbody *ngIf="displayedColumns.length > 0 && tableRows.length > 0">
+      <ng-container *ngFor="let row of tableRows">
+        <tr *ngIf="row.title !== undefined" class="separator-row">
+          <td [attr.colspan]="displayedColumns.length">
+            {{ row.title }} — {{ Number(row.total.toFixed(2)) }} €
+          </td>
+        </tr>
+        <tr *ngIf="row.title === undefined"
+            (click)="onGiftClicked(row as GiftFollowed)"
+            [class.recu]="(row as GiftFollowed).delivery?.recu"
+            [class.partage]="(row as GiftFollowed).gift.statut === 'PARTAGE'"
+            [attr.aria-label]="getAriaLabel(row as GiftFollowed)">
+          <td *ngFor="let column of displayedColumns"
+              tabindex="0"
+              (keydown.enter)="onGiftClicked(row as GiftFollowed)"
+              (keydown.space)="onGiftClicked(row as GiftFollowed)">
+            {{ getGiftValue(row as GiftFollowed, column) }}
+          </td>
+        </tr>
+      </ng-container>
     </tbody>
   </table>
 

--- a/frontend/src/pages/dashboard/suivi-cadeaux-reserves/my-gifts-follow-up/my-gifts-follow-up.component.scss
+++ b/frontend/src/pages/dashboard/suivi-cadeaux-reserves/my-gifts-follow-up/my-gifts-follow-up.component.scss
@@ -30,7 +30,8 @@
   }
 
   .partage {
-    background-color: var(--color-sharing);
+    border: 2px solid var(--color-sharing);
+    background-color: transparent;
   }
 }
 
@@ -72,13 +73,22 @@
 }
 
 .gift-table tr.partage {
-  background-color: var(--color-sharing);
-  color: var(--color-text);
+  outline: 2px solid var(--color-sharing);
+  outline-offset: -2px;
 }
 
 .gift-table td:focus {
   outline: 2px dashed var(--color-border);
   background-color: var(--color-row-hover-bg);
+}
+
+.separator-row {
+  font-weight: bold;
+  font-style: italic;
+  padding-top: 1rem;
+  color: var(--color-highlight);
+  background-color: var(--color-bg);
+  border-top: 2px solid var(--color-alt-border);
 }
 
 

--- a/frontend/src/pages/dashboard/suivi-cadeaux-reserves/my-gifts-follow-up/my-gifts-follow-up.component.ts
+++ b/frontend/src/pages/dashboard/suivi-cadeaux-reserves/my-gifts-follow-up/my-gifts-follow-up.component.ts
@@ -138,6 +138,10 @@ export class MyGiftsFollowUpComponent implements OnInit, OnDestroy{
     return column.formatFn ? column.formatFn(rawValue, giftFollowed) : rawValue;
   }
 
+  isGroupRow(row: GiftFollowed | GroupRow): row is GroupRow {
+    return (row as GroupRow).title !== undefined;
+  }
+
   private buildTableRows(): void {
     const groups = new Map<number | null, { label: string; gifts: GiftFollowed[] }>();
     for (const gift of this.giftsFollowed) {


### PR DESCRIPTION
## Summary
- group followed gifts by account tiers and show totals
- show group headers inside gifts table
- adjust shared/received styling with combined colors

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dc86a081c8330a5e04a436d9037dc