### PR TITLE
Fix pytest configuration for test discovery

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,9 +1,9 @@
-[tool:pytest]
+[pytest]
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =
     unit: marque les tests unitaires
-    integration: marque les tests d'intégration  
+    integration: marque les tests d'intégration
     slow: marque les tests lents
 testpaths = tests
 python_files = test_*.py
@@ -12,4 +12,5 @@ python_functions = test_*
 addopts = -v --tb=short --strict-markers
 filterwarnings =
     ignore::DeprecationWarning
-    ignore::PytestUnhandledCoroutineWarning
+    ignore::pytest.PytestUnhandledCoroutineWarning
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for project root.
+Ensures backend package is on sys.path when running tests from the repository root."""
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parent
+backend_path = root / "backend"
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 testpaths = backend/tests
@@ -8,8 +8,9 @@ python_functions = test_*
 addopts = -v --tb=short --strict-markers
 filterwarnings =
     ignore::DeprecationWarning
-    ignore::PytestUnhandledCoroutineWarning
+    ignore::pytest.PytestUnhandledCoroutineWarning
 markers =
     unit: marque les tests unitaires
-    integration: marque les tests d'intégration  
+    integration: marque les tests d'intégration
     slow: marque les tests lents
+


### PR DESCRIPTION
## Summary
- fix pytest.ini files to use the correct `[pytest]` section
- ensure warning filters are fully qualified

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68bc8f4a22248330909411389ce835e0